### PR TITLE
fix: add spacing below FOSSUnited logo on about page

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -166,6 +166,8 @@ hide_title = true
     width: auto;
     opacity: 0.75;
     transition: opacity 0.2s;
+    display: block;
+    margin: 0 auto 16px;
 }
 .about-supported a:hover img {
     opacity: 1;

--- a/content/about.md
+++ b/content/about.md
@@ -169,6 +169,9 @@ hide_title = true
     display: block;
     margin: 0 auto 16px;
 }
+.about-supported a {
+    display: block;
+}
 .about-supported a:hover img {
     opacity: 1;
 }


### PR DESCRIPTION
Adds 16px of margin below the FOSSUnited logo in the "Supported by" section of the About page for better visual breathing room.

Closes #15

Generated with [Claude Code](https://claude.ai/code)